### PR TITLE
Update ClippyContentCard.cs

### DIFF
--- a/Clippy/Cards/ClippyContentCard.cs
+++ b/Clippy/Cards/ClippyContentCard.cs
@@ -33,7 +33,7 @@ namespace Clippy.Cards
         /// Turns the card into an <see cref="Attachment"/>.
         /// </summary>
         /// <returns>An <see cref="Attachment"/>.</returns>
-        public Attachment ToAttachment()
+        public Attachment ToAttachment("1.0.3")
         {
             var card = new AdaptiveCard
             {


### PR DESCRIPTION
The newer version requires us to specify the version that this was built on. Tested against AdaptiveCards v1.1.2